### PR TITLE
[2.2.0]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 ############################################################################
 
 cmake_minimum_required(VERSION 3.0.0)
-project(half VERSION 2.1.2)
+project(half VERSION 2.2.0)
 
 include(CTest)
 enable_testing()

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+2.2.0 release (2020-10-14):
+---------------------------
+
+- Added direct assignment from any type
+- Added templated operators overloads to accept anything.
+  Args in them are will be converted to half and then used in regular operators for halfs.
+- Added useful CMakeLists. Special thanks to xtensor-stack (github) for useful examples in XTL;
+- Prepared for integration with xtensor-stack's repos like xtensor or xtl
+- Removed more obsolete code and defines
+
 2.1.1 release (2020-10-05):
 ---------------------------
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ straight-forward:
 
 ```C++
     using half_float::half;
-    half a(3.4), b(5);
+    half a = 3.4, b = 5;
     half c = a * b;
     c += 3;
     if(c > a)
@@ -39,7 +39,7 @@ Additionally the 'half_float' namespace also defines half-precision versions for
 directly through ADL:
 
 ```C++
-    half a(-3.14159);
+    half a = -3.14159;
     half s = sin(abs(a));
     long l = lround(s);
 ```
@@ -64,13 +64,9 @@ In contrast to the float-to-half conversion, which reduces precision, the conver
 The default rounding mode for conversions between half and more precise types as well as for rounding results of arithmetic operations and mathematical functions rounds to the nearest representable value. But by predefining the 'HALF_ROUND_STYLE' preprocessor symbol this default can be overridden with one of the other standard rounding modes using their respective constants or the equivalent values of 'std::float_round_style' (it can even be synchronized with the built-in single-precision implementation by defining it to 'std::numeric_limits<float>::round_style'):
 
   - 'std::round_indeterminate' (-1) for the fastest rounding.
-
   - 'std::round_toward_zero' (0) for rounding toward zero.
-
   - 'std::round_to_nearest' (1) for rounding to the nearest value (default).
-
   - 'std::round_toward_infinity' (2) for rounding toward positive infinity.
-
   - 'std::round_toward_neg_infinity' (3) for rounding toward negative infinity.
 
 In addition to changing the overall default rounding mode one can also use the 'half_cast'. This converts between half and any built-in arithmetic type using a configurable rounding mode (or the default rounding mode if none is specified). In addition to a configurable rounding mode, 'half_cast' has another big difference to a mere 'static_cast': Any conversions are performed directly using the given rounding mode, without any intermediate conversion to/from 'float'. This is especially relevant for conversions to integer types, which don't necessarily truncate anymore. But also for conversions from 'double' or 'long double' this may produce more precise results than a pre-conversion to 'float' using the single-precision implementation's current rounding mode would.

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -8,8 +8,8 @@ int main(int, char**) {
 
     auto f0 = 2.f;
     auto f1 = 3.f;
-    half h0(f0);
-    half h1(f1);
+    half h0 = f0;
+    half h1 = f1;
 
     assert((half)f0+(half)f1 == (float)(h0+h1));
     assert((half)f0-(half)f1 == (float)(h0-h1));
@@ -20,13 +20,16 @@ int main(int, char**) {
     auto is_fp = std::is_floating_point<half>::value;
     auto is_int = std::is_integral<half>::value;
     auto is_arithmetic = std::is_arithmetic<half>::value;
+    auto is_signed = std::is_signed<half>::value;
     std::cout << "is_scalar:" << is_scalar << "\n";
     std::cout << "is_floating_point:" << is_fp << "\n";
     std::cout << "is_integral:" << is_int << "\n";
     std::cout << "is_arithmetic:" << is_arithmetic << "\n";
+    std::cout << "is_signed:" << is_signed << "\n";
 
     assert(is_scalar);
     assert(is_fp);
     assert(!is_int);
     assert(is_arithmetic);
+    assert(is_signed);
 }


### PR DESCRIPTION
Added direct assignment from any type
Added templated operators overloads to accept anything.
Args in them are will be converted to half and then used in regular operators for halfs.
Added useful CMakeLists. Special thanks to xtensor-stack (github) for useful examples in XTL;
Prepared for integration with xtensor-stack's repos like xtensor or xtl
Removed more obsolete code and defines